### PR TITLE
python 3 compatability bug fix

### DIFF
--- a/gpipsfs/main.py
+++ b/gpipsfs/main.py
@@ -175,7 +175,7 @@ class GPI(poppy.Instrument):
     def obsmode_list(self):
         "Available Observation Modes"
         keys = self._obsmode_table.keys()
-        keys.sort()
+        keys = sorted(keys)
         return keys
 
     # Obsmode works differently since it's a meta-property that affects the other ones:


### PR DESCRIPTION
Fixed a bug which broke the class `GPI` in Python 3.

The bug can be seen using the iPython notebooks. For example, running the "Getting Started..." notebook in Python 3, returns an error message:

```

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-c3a308f9e62c> in <module>()
----> 1 gpi = gpipsfs.GPI()
      2 gpi.obsmode='H_coron'

/home/egentry/tmp/gpipsfs/gpipsfs/main.py in __init__(self, obsmode, npix, lyot_tabs, satspots, undersized_secondary, display_before, dms)
     99         self.dms=dms
    100         self._undersized_secondary=undersized_secondary # use the (erroneous) value we used in GPI design
--> 101         self.obsmode = obsmode
    102         self.options['output_mode'] = 'detector'  # by default, always bin down to GPI actual pixels
    103         self.npix=npix

/home/egentry/tmp/gpipsfs/gpipsfs/main.py in obsmode(self, value)
    190     @obsmode.setter
    191     def obsmode(self, value):
--> 192         if value not in self.obsmode_list:
    193             raise ValueError("Instrument {0} doesn't have an Obsmode called {1}.".format(self.name, value))
    194 

/home/egentry/tmp/gpipsfs/gpipsfs/main.py in obsmode_list(self)
    176         "Available Observation Modes"
    177         keys = self._obsmode_table.keys()
--> 178         keys.sort()
    179         return keys
    180 

AttributeError: 'dict_keys' object has no attribute 'sort'
```

This is caused by the return value of `keys()` Python 3 being of type `dict_keys` rather than type `list` which it is in Python 2.

Using `sorted` will both sort the list, as well as ensure `keys` will be of type `list` in Python 2 and 3.
